### PR TITLE
Add slot desktop up/down/restart commands for macOS layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ See [RELEASES.md](RELEASES.md) for versioning details.
 
 ## [Unreleased]
 
+### Added
+- New desktop layout commands:
+  - `slot desktop up` — Launch browser/editor pairs for running slots on sequential macOS Spaces
+  - `slot desktop down` — Close only windows managed by desktop up
+  - `slot desktop restart` — Rebuild layout (`down` then `up`)
+- Optional desktop configuration via `.slotdesktop` (or `.slotconfig`) with defaults for:
+  - `DESKTOP_START_SPACE`, `DESKTOP_LAYOUT`, `DESKTOP_BROWSER`, `DESKTOP_EDITOR`
+  - `DESKTOP_TOP_OFFSET`, `DESKTOP_SWITCH_DELAY`, `DESKTOP_WINDOW_TIMEOUT`
+- State tracking file `.slotdesktop.state` to safely target managed windows during cleanup
+
 ## [2.8.0] - 2026-02-01
 
 ### Changed
@@ -447,4 +457,3 @@ New variables in `config.local`:
 [1.2.0]: https://github.com/lchachurski/flowslot/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/lchachurski/flowslot/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/lchachurski/flowslot/releases/tag/v1.0.0
-

--- a/README.md
+++ b/README.md
@@ -233,6 +233,9 @@ slot server stop
 | `slot list` | Show all slots with port ranges |
 | `slot info [name]` | Show slot details (URLs, ports, status) |
 | `slot compose [name] <args>` | Run docker compose on remote slot |
+| `slot desktop up` | Build macOS layout (one Space per running slot) |
+| `slot desktop down` | Close only desktop windows managed by flowslot |
+| `slot desktop restart` | Rebuild desktop layout (`down` + `up`) |
 | `slot server start` | Start EC2 instance |
 | `slot server stop` | Stop EC2 instance |
 | `slot server status` | Show EC2 status |
@@ -264,6 +267,41 @@ slot compose build --no-cache      # Rebuild
 slot compose logs -f web           # Follow logs
 slot compose exec api bash         # Shell into container
 ```
+
+### Desktop Layout (macOS)
+
+`slot desktop up` launches one browser/editor pair per running slot and places each pair on sequential macOS Spaces:
+
+- Left half: browser (`DESKTOP_BROWSER`, default `Google Chrome`)
+- Right half: editor (`DESKTOP_EDITOR`, default `Cursor`)
+- Optional config in `.slotdesktop` (or `.slotconfig`):
+  - `DESKTOP_START_SPACE=3`
+  - `DESKTOP_LAYOUT="left-right"`
+  - `DESKTOP_BROWSER="Google Chrome"`
+  - `DESKTOP_EDITOR="Cursor"`
+  - `DESKTOP_TOP_OFFSET=28` (optional override; auto-detected when possible)
+
+Commands:
+
+```bash
+slot desktop up
+slot desktop down
+slot desktop restart
+```
+
+One-time setup:
+
+1. Open **System Settings → Desktop & Dock → Mission Control**
+2. Set **Automatically rearrange Spaces based on most recent use** to **OFF**
+3. Open **System Settings → Keyboard → Keyboard Shortcuts → Mission Control**
+4. Enable **Switch to Desktop 1 ... Desktop N** (Ctrl+1 ... Ctrl+N)
+5. Open Mission Control and create enough Spaces with the **+** button
+6. Grant Accessibility permission to your terminal app in **Privacy & Security → Accessibility**
+
+Notes:
+- `slot desktop` cannot create/move Spaces automatically (SIP-safe mode)
+- Space shortcuts are supported for Desktops 1-9
+- `slot desktop down` closes only windows tracked in `.slotdesktop.state`
 
 ---
 

--- a/config.example
+++ b/config.example
@@ -33,3 +33,22 @@ export TS_SPLIT_DOMAIN="flowslot.cc"
 # =============================================================================
 export AWS_KEY_NAME="flowslot-dev"
 
+# =============================================================================
+# OPTIONAL: `slot claude` — run Claude Code on slots with phone-call notifications.
+#
+# Per-project values are written to .slotconfig by `slot self init`; the ones
+# below are documented here for reference / manual configuration.
+#
+# FLOWSLOT_CALLMEBOT_PHONE    Phone number in international format (e.g. +46701234567)
+#                             For channel=telegram or channel=call, use a @username instead.
+# FLOWSLOT_CALLMEBOT_APIKEY   Your CallMeBot API key (get one at https://callmebot.com).
+# FLOWSLOT_CALLMEBOT_CHANNEL  whatsapp | signal | telegram | call  (default: whatsapp)
+#                               whatsapp/signal   → message (WhatsApp/Signal)
+#                               telegram          → Telegram message
+#                               call              → Telegram voice call (rings your phone)
+# FLOWSLOT_CALLMEBOT_URL_TEMPLATE  Optional override — a URL containing {PHONE},
+#                                  {APIKEY}, {TEXT} placeholders. Takes precedence
+#                                  over channel-based defaults.
+# SLOT_CLAUDE_DEFAULT         remote (default) or local — flip `slot claude` default.
+# =============================================================================
+

--- a/infra/flowslot-notify.sh
+++ b/infra/flowslot-notify.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# flowslot-notify — invoked by Claude Code hooks on a slot to call/message the user.
+#
+# Deployed to ~/.flowslot/bin/flowslot-notify by `slot claude` (see scripts/lib/claude.sh).
+# Config is sourced from ~/.flowslot/notify.conf (0600, written by deploy_notify_hook).
+#
+# Usage:
+#   flowslot-notify <event>    event ∈ { stop, notification }
+#
+# Config (sourced from ~/.flowslot/notify.conf):
+#   FLOWSLOT_CALLMEBOT_PHONE       Phone number in international format (e.g. +46701234567)
+#                                  For 'telegram' channel: a Telegram @username instead.
+#   FLOWSLOT_CALLMEBOT_APIKEY      CallMeBot API key (obtained per-channel from CallMeBot).
+#   FLOWSLOT_CALLMEBOT_CHANNEL     whatsapp | signal | telegram  (default: whatsapp)
+#   FLOWSLOT_CALLMEBOT_URL_TEMPLATE  Optional override: URL with {PHONE}, {APIKEY}, {TEXT} placeholders.
+#
+# Per-invocation env (set by `slot claude` when launching Claude):
+#   FLOWSLOT_SLOT_NAME, FLOWSLOT_PROJECT_NAME — used in the message body.
+#   FLOWSLOT_SILENT=1                         — skip notification (for automated runs).
+#
+# All output goes to ~/.flowslot/claude-session.log; hooks must stay quiet on stdout/stderr.
+
+set -u
+
+event="${1:-stop}"
+log="$HOME/.flowslot/claude-session.log"
+mkdir -p "$(dirname "$log")"
+
+log_line() { echo "[$(date -u +%FT%TZ)] $*" >> "$log"; }
+
+# Shortcut: caller asked to be quiet.
+if [ "${FLOWSLOT_SILENT:-0}" = "1" ]; then
+  log_line "silent mode, skipping $event"
+  exit 0
+fi
+
+conf="$HOME/.flowslot/notify.conf"
+if [ ! -f "$conf" ]; then
+  log_line "no notify.conf; skipping $event"
+  exit 0
+fi
+# shellcheck disable=SC1090
+. "$conf"
+
+phone="${FLOWSLOT_CALLMEBOT_PHONE:-}"
+apikey="${FLOWSLOT_CALLMEBOT_APIKEY:-}"
+channel="${FLOWSLOT_CALLMEBOT_CHANNEL:-whatsapp}"
+
+if [ -z "$phone" ] || [ -z "$apikey" ]; then
+  log_line "notify.conf missing phone/apikey; skipping $event"
+  exit 0
+fi
+
+slot="${FLOWSLOT_SLOT_NAME:-$(basename "$PWD" | sed -E 's/-[0-9]{4}$//')}"
+project="${FLOWSLOT_PROJECT_NAME:-$(basename "$(dirname "$PWD")")}"
+
+case "$event" in
+  stop)         msg="Claude finished task on slot '${slot}' (${project})." ;;
+  notification) msg="Claude needs your input on slot '${slot}' (${project})." ;;
+  *)            msg="Claude event '${event}' on slot '${slot}' (${project})." ;;
+esac
+
+# URL-encode the message body. Prefer jq, which is installed as a dependency.
+urlencode() {
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$1" | jq -sRr @uri
+  else
+    # Minimal fallback — only safe because msg content is controlled by this script.
+    python3 -c 'import sys,urllib.parse; print(urllib.parse.quote(sys.argv[1]))' "$1" 2>/dev/null \
+      || printf '%s' "$1" | sed 's/ /%20/g'
+  fi
+}
+text_enc="$(urlencode "$msg")"
+
+# Choose endpoint.
+if [ -n "${FLOWSLOT_CALLMEBOT_URL_TEMPLATE:-}" ]; then
+  url="$FLOWSLOT_CALLMEBOT_URL_TEMPLATE"
+  url="${url//\{PHONE\}/$phone}"
+  url="${url//\{APIKEY\}/$apikey}"
+  url="${url//\{TEXT\}/$text_enc}"
+else
+  case "$channel" in
+    whatsapp)
+      url="https://api.callmebot.com/whatsapp.php?phone=${phone}&apikey=${apikey}&text=${text_enc}"
+      ;;
+    signal)
+      url="https://api.callmebot.com/signal/send.php?phone=${phone}&apikey=${apikey}&text=${text_enc}"
+      ;;
+    telegram)
+      # For telegram, 'phone' is expected to be @username; apikey is ignored by CallMeBot's text.php.
+      url="https://api.callmebot.com/text.php?user=${phone}&text=${text_enc}"
+      ;;
+    call)
+      # CallMeBot voice call (Telegram-based). 'phone' must be a Telegram @username.
+      url="http://api.callmebot.com/start.php?source=web&user=${phone}&text=${text_enc}"
+      ;;
+    *)
+      log_line "unknown channel '$channel'; skipping"
+      exit 0
+      ;;
+  esac
+fi
+
+log_line "notify $event → channel=$channel"
+http_code="$(curl -fsS --max-time 10 -o /dev/null -w '%{http_code}' "$url" 2>>"$log" || echo 000)"
+log_line "  http=$http_code"
+
+# Never surface errors to Claude — hooks must not block or pollute output.
+exit 0

--- a/scripts/lib/claude.sh
+++ b/scripts/lib/claude.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# Helpers for the `slot claude` command.
+# Sourced by scripts/slot-claude. Depends on scripts/lib/common.sh being sourced
+# first (for log_info / log_warn / log_error / remote_ssh).
+
+# Remote locations, relative to the slot user's $HOME.
+readonly FLOWSLOT_REMOTE_DIR='$HOME/.flowslot'
+readonly FLOWSLOT_NOTIFY_BIN_REL='.flowslot/bin/flowslot-notify'
+readonly FLOWSLOT_NOTIFY_CONF_REL='.flowslot/notify.conf'
+readonly FLOWSLOT_INSTALL_MARKER_REL='.flowslot/claude-installed'
+readonly FLOWSLOT_READY_MARKER_REL='.flowslot/claude-ready'
+
+# Install Claude Code on the slot if not already present.
+# Per-EC2 (not per-slot) — one ubuntu user shares the install across slots.
+ensure_claude_installed() {
+  local host="$1"
+  if ssh "$host" 'test -f "$HOME/'"$FLOWSLOT_INSTALL_MARKER_REL"'" && (test -x "$HOME/.local/bin/claude" || command -v claude >/dev/null 2>&1)' 2>/dev/null; then
+    return 0
+  fi
+
+  log_info "Installing Claude Code on slot (one-time, ~30s)..."
+  ssh "$host" bash << 'REMOTE_INSTALL'
+    set -e
+    mkdir -p "$HOME/.flowslot/bin"
+
+    # Install prerequisites (jq is needed later for settings.json merge).
+    if ! command -v jq >/dev/null 2>&1; then
+      sudo apt-get update -qq
+      sudo apt-get install -y jq curl >/dev/null
+    fi
+
+    # Run the official installer only if claude isn't present.
+    if ! test -x "$HOME/.local/bin/claude" && ! command -v claude >/dev/null 2>&1; then
+      curl -fsSL https://claude.ai/install.sh | bash
+    fi
+
+    # Make sure future non-interactive ssh sessions find claude on PATH.
+    if ! grep -q 'flowslot-claude-path' "$HOME/.bashrc" 2>/dev/null; then
+      cat >> "$HOME/.bashrc" << 'BRC'
+# flowslot-claude-path
+case ":$PATH:" in *":$HOME/.local/bin:"*) ;; *) export PATH="$HOME/.local/bin:$PATH" ;; esac
+BRC
+    fi
+
+    date -u +%FT%TZ > "$HOME/.flowslot/claude-installed"
+REMOTE_INSTALL
+}
+
+# rsync the user's ~/.claude credentials + settings to the slot.
+# Called on every `slot claude` invocation so rotated OAuth tokens propagate.
+# Returns 1 if local credentials file is missing (caller decides fallback).
+sync_claude_auth() {
+  local host="$1"
+
+  if [ ! -f "$HOME/.claude/credentials.json" ]; then
+    log_warn "No local ~/.claude/credentials.json — skipping auth sync."
+    log_warn "Run 'claude /login' locally once, then rerun; or run /login inside the slot's tmux session."
+    return 1
+  fi
+
+  ssh "$host" 'mkdir -p "$HOME/.claude"' 2>/dev/null
+
+  local to_sync=("$HOME/.claude/credentials.json")
+  [ -f "$HOME/.claude/settings.json" ] && to_sync+=("$HOME/.claude/settings.json")
+
+  # --chmod=F600 mirrors the sensitive perms of credentials.json.
+  if ! rsync -az --chmod=F600 "${to_sync[@]}" "$host:.claude/" 2>/dev/null; then
+    log_warn "Credential rsync failed."
+    return 1
+  fi
+  return 0
+}
+
+# Deploy the notify script to the slot and merge hooks into ~/.claude/settings.json.
+# Idempotent; safe to call on every invocation.
+# $1 = ssh host, $2 = absolute path to flowslot repo on local machine.
+deploy_notify_hook() {
+  local host="$1"
+  local flowslot_root="$2"
+
+  # 1) Copy the notify script.
+  ssh "$host" 'mkdir -p "$HOME/.flowslot/bin"'
+  rsync -az --chmod=F755 "$flowslot_root/infra/flowslot-notify.sh" \
+    "$host:.flowslot/bin/flowslot-notify" 2>/dev/null
+
+  # 2) Write notify.conf with CallMeBot creds (0600).
+  ssh "$host" bash -s -- \
+    "${FLOWSLOT_CALLMEBOT_PHONE:-}" \
+    "${FLOWSLOT_CALLMEBOT_APIKEY:-}" \
+    "${FLOWSLOT_CALLMEBOT_CHANNEL:-whatsapp}" << 'REMOTE_CONF'
+    set -e
+    phone="$1"
+    apikey="$2"
+    channel="$3"
+    conf="$HOME/.flowslot/notify.conf"
+    umask 077
+    cat > "$conf" << CONF
+FLOWSLOT_CALLMEBOT_PHONE="${phone}"
+FLOWSLOT_CALLMEBOT_APIKEY="${apikey}"
+FLOWSLOT_CALLMEBOT_CHANNEL="${channel}"
+CONF
+REMOTE_CONF
+
+  # 3) Merge hook block into ~/.claude/settings.json using jq.
+  ssh "$host" bash << 'REMOTE_MERGE'
+    set -e
+    settings="$HOME/.claude/settings.json"
+    notify="$HOME/.flowslot/bin/flowslot-notify"
+    mkdir -p "$(dirname "$settings")"
+    [ -f "$settings" ] || echo '{}' > "$settings"
+
+    tmp="$(mktemp)"
+    jq --arg notify "$notify" '
+      .hooks = (.hooks // {})
+      | .hooks.Stop = [{ matcher: ".*", hooks: [{ type: "command", command: ($notify + " stop") }] }]
+      | .hooks.Notification = [{ matcher: ".*", hooks: [{ type: "command", command: ($notify + " notification") }] }]
+    ' "$settings" > "$tmp" && mv "$tmp" "$settings"
+REMOTE_MERGE
+}
+
+# Quick sanity check that Claude can authenticate headlessly.
+# Returns 0 on success, 1 if auth is broken (caller should fall back to tmux /login).
+# Bypasses .bashrc, which typically short-circuits for non-interactive shells.
+verify_claude_auth() {
+  local host="$1"
+  ssh "$host" 'PATH="$HOME/.local/bin:$PATH" claude -p --max-turns 0 "ping" >/dev/null 2>&1' \
+    </dev/null >/dev/null 2>&1
+}
+
+# Mark a slot host as bootstrapped so subsequent calls skip the slow install+verify path.
+mark_claude_ready() {
+  local host="$1"
+  ssh "$host" 'date -u +%FT%TZ > "$HOME/.flowslot/claude-ready"' 2>/dev/null || true
+}
+
+# Returns 0 if the slot has already been bootstrapped successfully.
+claude_is_ready() {
+  local host="$1"
+  ssh "$host" 'test -f "$HOME/.flowslot/claude-ready"' 2>/dev/null
+}
+
+# Readable rendering of `claude --output-format stream-json` on stdin.
+# Best-effort: unknown event shapes are passed through as raw JSON.
+pretty_print_stream_json() {
+  if ! command -v jq >/dev/null 2>&1; then
+    cat
+    return
+  fi
+  jq -r '
+    if .type == "assistant" and (.message.content // [])[0].text then
+      (.message.content[] | select(.type=="text") | .text)
+    elif .type == "tool_use" or (.message.content // [])[0].type == "tool_use" then
+      "[tool] " + ((.message.content // [])[0].name // .name // "?")
+    elif .type == "result" then
+      "\n[done] " + (.result // .text // "")
+    elif .type == "error" then
+      "[error] " + (.error // tostring)
+    else
+      empty
+    end
+  ' 2>/dev/null
+}
+
+# Session name for tmux, scoped per-slot so multiple slots don't collide.
+claude_tmux_session() {
+  local slot_name="$1"
+  echo "claude-${slot_name}"
+}

--- a/scripts/slot
+++ b/scripts/slot
@@ -34,6 +34,11 @@ SLOT OPERATIONS:
   info [name]       Show slot details (URLs, ports, containers)
   compose [name]    Proxy docker compose commands to remote slot
 
+DESKTOP:
+  desktop up        Launch desktop layout (one Space per running slot)
+  desktop down      Close windows managed by desktop up
+  desktop restart   Rebuild desktop layout (down + up)
+
 SERVER:
   server start      Start EC2 instance
   server stop       Stop EC2 instance
@@ -148,6 +153,50 @@ case "$1" in
     set +a
     "$SCRIPT_DIR/slot-compose" "$@"
     ;;
+  desktop)
+    shift
+    if ! CONFIG_FILE=$(find_config); then
+      die ".slotconfig not found. Run 'slot self init' first."
+    fi
+    # shellcheck source=/dev/null
+    set -a
+    source "$CONFIG_FILE"
+    set +a
+
+    if [ -z "${1:-}" ]; then
+      log_error "Subcommand required for 'slot desktop'"
+      echo ""
+      echo "Available subcommands:"
+      echo "  up       Launch Chrome + Cursor per running slot"
+      echo "  down     Close windows managed by 'slot desktop up'"
+      echo "  restart  Run down then up"
+      exit 1
+    fi
+
+    case "$1" in
+      up)
+        shift
+        "$SCRIPT_DIR/slot-desktop-up.sh" "$@"
+        ;;
+      down)
+        shift
+        "$SCRIPT_DIR/slot-desktop-down.sh" "$@"
+        ;;
+      restart)
+        shift
+        "$SCRIPT_DIR/slot-desktop-restart.sh" "$@"
+        ;;
+      *)
+        log_error "Unknown subcommand: $1"
+        echo ""
+        echo "Available subcommands:"
+        echo "  up       Launch Chrome + Cursor per running slot"
+        echo "  down     Close windows managed by 'slot desktop up'"
+        echo "  restart  Run down then up"
+        exit 1
+        ;;
+    esac
+    ;;
   server)
     shift
     if CONFIG_FILE=$(find_config 2>/dev/null); then
@@ -198,4 +247,3 @@ case "$1" in
     exit 1
     ;;
 esac
-

--- a/scripts/slot
+++ b/scripts/slot
@@ -34,6 +34,14 @@ SLOT OPERATIONS:
   info [name]       Show slot details (URLs, ports, containers)
   compose [name]    Proxy docker compose commands to remote slot
 
+AI:
+  claude [prompt]   Run Claude Code on a slot (interactive tmux by default)
+  claude --headless <prompt>
+                    Run Claude headlessly on the slot; phone-call on finish
+  claude --local    Run Claude locally instead of on the slot
+  claude attach     Reattach to a slot's running Claude tmux session
+  claude logs [-f]  Show the notify log on the slot
+
 DESKTOP:
   desktop up        Launch desktop layout (one Space per running slot)
   desktop down      Close windows managed by desktop up
@@ -152,6 +160,17 @@ case "$1" in
     source "$CONFIG_FILE"
     set +a
     "$SCRIPT_DIR/slot-compose" "$@"
+    ;;
+  claude)
+    shift
+    if ! CONFIG_FILE=$(find_config); then
+      die ".slotconfig not found. Run 'slot self init' first."
+    fi
+    # shellcheck source=/dev/null
+    set -a
+    source "$CONFIG_FILE"
+    set +a
+    "$SCRIPT_DIR/slot-claude" "$@"
     ;;
   desktop)
     shift

--- a/scripts/slot-claude
+++ b/scripts/slot-claude
@@ -1,0 +1,244 @@
+#!/bin/bash
+# Run Claude Code on a slot (or locally). Notify the user via phone call when
+# Claude finishes a task or needs input.
+#
+# Default mode: interactive tmux session on the slot.
+# See `slot claude --help` for other modes.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/lib"
+FLOWSLOT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# shellcheck source=lib/common.sh
+source "$LIB_DIR/common.sh"
+# shellcheck source=lib/claude.sh
+source "$LIB_DIR/claude.sh"
+
+show_help() {
+  cat << EOF
+Usage: slot claude [options] [prompt...]
+       slot claude <subcommand> [options]
+
+Run Claude Code on a slot. By default drops into a persistent tmux session on
+the remote slot so long agentic tasks survive laptop sleep. You'll get a phone
+call (via CallMeBot) when Claude finishes a task or asks a question.
+
+Subcommands:
+  attach            Reattach to the slot's running Claude tmux session.
+  logs [-f]         Show (or tail) the notify log on the slot.
+  bootstrap         Install Claude + sync creds + deploy notify hook (normally
+                    implicit on first use). Use to refresh after token rotation.
+  status            Show install/auth/session state for the slot.
+
+Options (default mode):
+  --slot <name>     Target slot (default: auto-detect from current directory).
+  --local           Run Claude locally in SLOT_SOURCE_DIR, no SSH, no hooks.
+  --headless        Non-interactive run. Streams stream-json output locally,
+                    still fires the phone call when done.
+  --silent          Suppress the phone call for this run (env FLOWSLOT_SILENT=1).
+  --refresh         Force re-run of install / auth sync / hook deploy.
+  -h, --help        Show this help.
+
+Examples:
+  slot claude                                 # Interactive tmux on the current slot
+  slot claude "refactor src/db.ts"            # Interactive, opens with this prompt
+  slot claude --headless "run the test suite and summarize failures"
+  slot claude --local                         # Run locally instead
+  slot claude attach                          # Reattach to existing session
+  slot claude logs -f                         # Tail notify log on the slot
+EOF
+}
+
+# -----------------------------------------------------------------------------
+# Argument parsing
+# -----------------------------------------------------------------------------
+
+MODE=""              # "", "attach", "logs", "bootstrap", "status"
+LOCAL=0
+HEADLESS=0
+SILENT=0
+REFRESH=0
+FOLLOW=0
+EXPLICIT_SLOT=""
+PROMPT_ARGS=()
+
+# First positional may be a subcommand keyword.
+if [ $# -gt 0 ]; then
+  case "$1" in
+    attach|logs|bootstrap|status) MODE="$1"; shift ;;
+    -h|--help) show_help; exit 0 ;;
+  esac
+fi
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --slot)      EXPLICIT_SLOT="${2:-}"; shift 2 ;;
+    --local)     LOCAL=1; shift ;;
+    --headless)  HEADLESS=1; shift ;;
+    --silent)    SILENT=1; shift ;;
+    --refresh)   REFRESH=1; shift ;;
+    -f|--follow) FOLLOW=1; shift ;;
+    -h|--help)   show_help; exit 0 ;;
+    --)          shift; PROMPT_ARGS+=("$@"); break ;;
+    *)           PROMPT_ARGS+=("$1"); shift ;;
+  esac
+done
+
+# Default-mode flag from .slotconfig: flip to --local unless explicitly overridden.
+if [ "$MODE" = "" ] && [ $LOCAL -eq 0 ] && [ "${SLOT_CLAUDE_DEFAULT:-remote}" = "local" ]; then
+  LOCAL=1
+fi
+
+# -----------------------------------------------------------------------------
+# Local mode: just exec claude in SLOT_SOURCE_DIR. No SSH, no hooks.
+# -----------------------------------------------------------------------------
+if [ $LOCAL -eq 1 ]; then
+  require_cmd claude
+  target_dir="${SLOT_SOURCE_DIR:-$PWD}"
+  [ -d "$target_dir" ] || die "SLOT_SOURCE_DIR not set or doesn't exist: $target_dir"
+  cd "$target_dir"
+  if [ $HEADLESS -eq 1 ]; then
+    [ ${#PROMPT_ARGS[@]} -gt 0 ] || die "--headless requires a prompt"
+    exec claude -p "${PROMPT_ARGS[*]}"
+  else
+    exec claude "${PROMPT_ARGS[@]}"
+  fi
+fi
+
+# -----------------------------------------------------------------------------
+# Remote mode: need slot name + remote path.
+# -----------------------------------------------------------------------------
+[ -n "${SLOT_REMOTE_HOST:-}" ] || die "SLOT_REMOTE_HOST not set (is .slotconfig loaded?)"
+[ -n "${SLOT_REMOTE_BASE:-}" ] || die "SLOT_REMOTE_BASE not set (is .slotconfig loaded?)"
+
+if [ -n "$EXPLICIT_SLOT" ]; then
+  SLOT_NAME="$EXPLICIT_SLOT"
+elif SLOT_NAME=$(detect_slot_name 2>/dev/null); then
+  :
+else
+  die "Slot name required. Use --slot <name> or run from inside a slot directory."
+fi
+validate_slot_name "$SLOT_NAME"
+
+REMOTE_PATH=$(find_slot_dir "$SLOT_REMOTE_BASE" "$SLOT_NAME" "$SLOT_REMOTE_HOST") \
+  || die "Slot '$SLOT_NAME' not found on $SLOT_REMOTE_HOST:$SLOT_REMOTE_BASE. Run 'slot create $SLOT_NAME' first."
+
+TMUX_SESSION=$(claude_tmux_session "$SLOT_NAME")
+
+# -----------------------------------------------------------------------------
+# Simple subcommands (attach, logs, status)
+# -----------------------------------------------------------------------------
+case "$MODE" in
+  attach)
+    if ! ssh "$SLOT_REMOTE_HOST" "tmux has-session -t '$TMUX_SESSION' 2>/dev/null"; then
+      die "No Claude session on slot '$SLOT_NAME'. Start one with: slot claude --slot $SLOT_NAME"
+    fi
+    exec remote_ssh_tty "$SLOT_REMOTE_HOST" "tmux attach -t '$TMUX_SESSION'"
+    ;;
+  logs)
+    if [ $FOLLOW -eq 1 ]; then
+      exec remote_ssh_tty "$SLOT_REMOTE_HOST" 'tail -F "$HOME/.flowslot/claude-session.log" 2>/dev/null'
+    else
+      exec ssh "$SLOT_REMOTE_HOST" 'test -f "$HOME/.flowslot/claude-session.log" && cat "$HOME/.flowslot/claude-session.log" || echo "(no log yet)"'
+    fi
+    ;;
+  status)
+    echo "Slot:        $SLOT_NAME"
+    echo "Remote path: $SLOT_REMOTE_HOST:$REMOTE_PATH"
+    if claude_is_ready "$SLOT_REMOTE_HOST"; then
+      echo "Bootstrap:   ready"
+    else
+      echo "Bootstrap:   not yet (first 'slot claude' will set up)"
+    fi
+    if ssh "$SLOT_REMOTE_HOST" "tmux has-session -t '$TMUX_SESSION' 2>/dev/null"; then
+      echo "Tmux:        session '$TMUX_SESSION' running"
+    else
+      echo "Tmux:        no active session"
+    fi
+    exit 0
+    ;;
+esac
+
+# -----------------------------------------------------------------------------
+# Bootstrap: install claude, sync creds, deploy hook. Idempotent.
+# -----------------------------------------------------------------------------
+bootstrap_slot() {
+  ensure_claude_installed "$SLOT_REMOTE_HOST"
+  if ! sync_claude_auth "$SLOT_REMOTE_HOST"; then
+    log_warn "Auth sync skipped or failed — you'll need to /login inside the tmux session."
+  fi
+  deploy_notify_hook "$SLOT_REMOTE_HOST" "$FLOWSLOT_ROOT"
+
+  if verify_claude_auth "$SLOT_REMOTE_HOST"; then
+    mark_claude_ready "$SLOT_REMOTE_HOST"
+    log_info "Claude is ready on slot '$SLOT_NAME'."
+  else
+    log_warn "Claude is installed but auth check failed."
+    log_warn "Dropping into tmux; inside Claude run '/login' once, then ctrl-b d to detach."
+  fi
+}
+
+if [ "$MODE" = "bootstrap" ] || [ $REFRESH -eq 1 ] || ! claude_is_ready "$SLOT_REMOTE_HOST"; then
+  bootstrap_slot
+fi
+
+[ "$MODE" = "bootstrap" ] && exit 0
+
+# -----------------------------------------------------------------------------
+# Build the remote claude invocation.
+# -----------------------------------------------------------------------------
+REMOTE_ENV=(
+  "FLOWSLOT_SLOT_NAME='$SLOT_NAME'"
+  "FLOWSLOT_PROJECT_NAME='${SLOT_PROJECT_NAME:-unknown}'"
+)
+[ $SILENT -eq 1 ] && REMOTE_ENV+=("FLOWSLOT_SILENT=1")
+
+REMOTE_ENV_STR="${REMOTE_ENV[*]}"
+
+CLAUDE_FLAGS="--dangerously-skip-permissions"
+
+if [ $HEADLESS -eq 1 ]; then
+  # -----------------------------------------------------------------------------
+  # Headless mode: stream-json over SSH, pretty-printed locally.
+  # -----------------------------------------------------------------------------
+  [ ${#PROMPT_ARGS[@]} -gt 0 ] || die "--headless requires a prompt"
+  # Escape prompt for single-quoted embedding.
+  prompt_str="${PROMPT_ARGS[*]}"
+  prompt_escaped="${prompt_str//\'/\'\\\'\'}"
+
+  log_info "Running Claude on slot '$SLOT_NAME' (headless)..."
+  # shellcheck disable=SC2029
+  ssh "$SLOT_REMOTE_HOST" "export $REMOTE_ENV_STR; \
+    export PATH=\"\$HOME/.local/bin:\$PATH\"; \
+    cd '$REMOTE_PATH' && \
+    claude -p $CLAUDE_FLAGS --output-format stream-json --verbose '$prompt_escaped'" \
+    | pretty_print_stream_json
+  exit ${PIPESTATUS[0]}
+fi
+
+# -----------------------------------------------------------------------------
+# Interactive tmux mode (default).
+# -----------------------------------------------------------------------------
+# Build the inner command that tmux will run.
+if [ ${#PROMPT_ARGS[@]} -gt 0 ]; then
+  prompt_str="${PROMPT_ARGS[*]}"
+  prompt_escaped="${prompt_str//\'/\'\\\'\'}"
+  INNER="claude $CLAUDE_FLAGS '$prompt_escaped'"
+else
+  INNER="claude $CLAUDE_FLAGS"
+fi
+
+# Build the remote shell command:
+#   1. Export FLOWSLOT_* for hook context.
+#   2. Ensure PATH picks up ~/.local/bin.
+#   3. tmux new-session -A -s <name> -c <path> <claude command>
+#      -A attaches if session exists, creates otherwise.
+REMOTE_CMD="export $REMOTE_ENV_STR; \
+export PATH=\"\$HOME/.local/bin:\$PATH\"; \
+tmux new-session -A -s '$TMUX_SESSION' -c '$REMOTE_PATH' \"$INNER\""
+
+log_info "Attaching to Claude on slot '$SLOT_NAME' (tmux: $TMUX_SESSION)..."
+log_info "  Detach with Ctrl-b d — the session keeps running."
+exec remote_ssh_tty "$SLOT_REMOTE_HOST" "$REMOTE_CMD"

--- a/scripts/slot-desktop-down.sh
+++ b/scripts/slot-desktop-down.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# Close desktop windows created by slot desktop up (macOS only)
+# Usage: slot desktop down
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/lib"
+
+# shellcheck source=lib/common.sh
+source "$LIB_DIR/common.sh"
+
+show_help() {
+  cat << EOF
+Usage: slot desktop down
+
+Close browser/editor windows tracked in .slotdesktop.state.
+
+Notes:
+  - Only windows tracked by 'slot desktop up' are targeted
+  - Personal browser/editor windows are left untouched
+EOF
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  show_help
+  exit 0
+fi
+
+require_cmd osascript
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  die "slot desktop commands are supported only on macOS."
+fi
+
+if [ -z "${SLOT_SOURCE_DIR:-}" ]; then
+  die "Missing SLOT_SOURCE_DIR. Run via 'slot desktop down' from an initialized project."
+fi
+
+DESKTOP_CONFIG_FILE="$SLOT_SOURCE_DIR/.slotdesktop"
+if [ -f "$DESKTOP_CONFIG_FILE" ]; then
+  # shellcheck source=/dev/null
+  source "$DESKTOP_CONFIG_FILE"
+fi
+
+DESKTOP_BROWSER="${DESKTOP_BROWSER:-Google Chrome}"
+DESKTOP_EDITOR="${DESKTOP_EDITOR:-Cursor}"
+DESKTOP_STATE_FILE="${DESKTOP_STATE_FILE:-$SLOT_SOURCE_DIR/.slotdesktop.state}"
+
+close_cursor_windows() {
+  local slot_name="$1"
+  local closed
+
+  closed="$(osascript << APPLESCRIPT 2>/dev/null || true
+tell application "$DESKTOP_EDITOR"
+  if not running then return "0"
+  set closedCount to 0
+  repeat with i from (count of windows) to 1 by -1
+    try
+      set windowName to name of window i
+      if windowName contains "$slot_name" then
+        close window i
+        set closedCount to closedCount + 1
+      end if
+    end try
+  end repeat
+  return closedCount as text
+end tell
+APPLESCRIPT
+)"
+
+  if [[ "$closed" =~ ^[0-9]+$ ]]; then
+    echo "$closed"
+  else
+    echo "0"
+  fi
+}
+
+close_browser_windows() {
+  local host_port="$1"
+  local port="$2"
+  local closed
+
+  closed="$(osascript << APPLESCRIPT 2>/dev/null || true
+tell application "$DESKTOP_BROWSER"
+  if not running then return "0"
+  set closedCount to 0
+  repeat with i from (count of windows) to 1 by -1
+    try
+      set tabURL to URL of active tab of window i
+      set shouldClose to false
+      if tabURL contains "$host_port" then
+        set shouldClose to true
+      else if "$port" is not "" then
+        if tabURL contains ("localhost:" & "$port") then set shouldClose to true
+        if tabURL contains ("flowslot.dev:" & "$port") then set shouldClose to true
+        if tabURL contains ("flowslot.cc:" & "$port") then set shouldClose to true
+      end if
+
+      if shouldClose then
+        close window i
+        set closedCount to closedCount + 1
+      end if
+    end try
+  end repeat
+  return closedCount as text
+end tell
+APPLESCRIPT
+)"
+
+  if [[ "$closed" =~ ^[0-9]+$ ]]; then
+    echo "$closed"
+  else
+    echo "0"
+  fi
+}
+
+if [ ! -f "$DESKTOP_STATE_FILE" ]; then
+  log_info "No desktop state file found at $DESKTOP_STATE_FILE. Nothing to close."
+  exit 0
+fi
+
+declare -a SUMMARY_LINES=()
+total_editor_closed=0
+total_browser_closed=0
+slots_processed=0
+
+while IFS='|' read -r slot_name slot_space slot_dir slot_url; do
+  [ -z "${slot_name:-}" ] && continue
+  [[ "$slot_name" =~ ^# ]] && continue
+  [ -z "${slot_url:-}" ] && continue
+
+  host_port="${slot_url#http://}"
+  host_port="${host_port%%/*}"
+  port="${host_port##*:}"
+  if [ "$port" = "$host_port" ]; then
+    port=""
+  fi
+
+  editor_closed="$(close_cursor_windows "$slot_name")"
+  browser_closed="$(close_browser_windows "$host_port" "$port")"
+
+  total_editor_closed=$((total_editor_closed + editor_closed))
+  total_browser_closed=$((total_browser_closed + browser_closed))
+  slots_processed=$((slots_processed + 1))
+
+  SUMMARY_LINES+=("${slot_name}|${slot_space}|${editor_closed}|${browser_closed}")
+done < "$DESKTOP_STATE_FILE"
+
+rm -f "$DESKTOP_STATE_FILE"
+
+success "Desktop windows closed."
+echo ""
+printf "%-15s %-8s %-12s %-12s\n" "SLOT" "SPACE" "EDITOR" "BROWSER"
+echo "-------------------------------------------------------"
+for row in "${SUMMARY_LINES[@]}"; do
+  IFS='|' read -r slot_name slot_space editor_closed browser_closed <<< "$row"
+  printf "%-15s %-8s %-12s %-12s\n" "$slot_name" "${slot_space:-?}" "$editor_closed" "$browser_closed"
+done
+
+echo ""
+echo "Slots processed: $slots_processed"
+echo "Editor windows closed: $total_editor_closed"
+echo "Browser windows closed: $total_browser_closed"

--- a/scripts/slot-desktop-restart.sh
+++ b/scripts/slot-desktop-restart.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Restart desktop layout (down + up)
+# Usage: slot desktop restart
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/lib"
+
+# shellcheck source=lib/common.sh
+source "$LIB_DIR/common.sh"
+
+show_help() {
+  cat << EOF
+Usage: slot desktop restart
+
+Close managed desktop windows, then relaunch layout for running slots.
+Equivalent to:
+  slot desktop down
+  slot desktop up
+EOF
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  show_help
+  exit 0
+fi
+
+log_info "Resetting desktop layout..."
+"$SCRIPT_DIR/slot-desktop-down.sh"
+"$SCRIPT_DIR/slot-desktop-up.sh"

--- a/scripts/slot-desktop-up.sh
+++ b/scripts/slot-desktop-up.sh
@@ -1,0 +1,516 @@
+#!/bin/bash
+# Build desktop layout for running slots (macOS only)
+# Usage: slot desktop up
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/lib"
+
+# shellcheck source=lib/common.sh
+source "$LIB_DIR/common.sh"
+
+show_help() {
+  cat << EOF
+Usage: slot desktop up
+
+Launch browser + editor windows for each running slot and place each pair
+on sequential macOS Spaces.
+
+Defaults (override in .slotconfig or .slotdesktop):
+  DESKTOP_START_SPACE=1
+  DESKTOP_LAYOUT=left-right
+  DESKTOP_BROWSER="Google Chrome"
+  DESKTOP_EDITOR="Cursor"
+  DESKTOP_TOP_OFFSET=<auto> (fallback: 28)
+  DESKTOP_SWITCH_DELAY=0.6
+  DESKTOP_WINDOW_TIMEOUT=10
+
+Notes:
+  - Requires macOS Accessibility permissions for your terminal app
+  - Requires Mission Control shortcuts: Ctrl+1 ... Ctrl+9
+  - Only Space shortcuts 1-9 are supported
+EOF
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  show_help
+  exit 0
+fi
+
+require_cmd osascript
+require_cmd open
+require_cmd ssh
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  die "slot desktop commands are supported only on macOS."
+fi
+
+if [ -z "${SLOT_PROJECT_NAME:-}" ] || [ -z "${SLOT_SOURCE_DIR:-}" ] || [ -z "${SLOT_SLOTS_DIR:-}" ] || [ -z "${SLOT_REMOTE_HOST:-}" ] || [ -z "${SLOT_REMOTE_BASE:-}" ]; then
+  die "Missing required SLOT_* variables. Run via 'slot desktop up' from an initialized project."
+fi
+
+DESKTOP_CONFIG_FILE="$SLOT_SOURCE_DIR/.slotdesktop"
+if [ -f "$DESKTOP_CONFIG_FILE" ]; then
+  # shellcheck source=/dev/null
+  source "$DESKTOP_CONFIG_FILE"
+fi
+
+DESKTOP_START_SPACE="${DESKTOP_START_SPACE:-1}"
+DESKTOP_LAYOUT="${DESKTOP_LAYOUT:-left-right}"
+DESKTOP_BROWSER="${DESKTOP_BROWSER:-Google Chrome}"
+DESKTOP_EDITOR="${DESKTOP_EDITOR:-Cursor}"
+DESKTOP_SWITCH_DELAY="${DESKTOP_SWITCH_DELAY:-0.6}"
+DESKTOP_WINDOW_TIMEOUT="${DESKTOP_WINDOW_TIMEOUT:-10}"
+DESKTOP_STATE_FILE="${DESKTOP_STATE_FILE:-$SLOT_SOURCE_DIR/.slotdesktop.state}"
+
+detect_menu_bar_height() {
+  local height
+  height="$(osascript << 'APPLESCRIPT' 2>/dev/null || true
+tell application "System Events"
+  tell process "SystemUIServer"
+    if exists menu bar 1 then
+      set menuSize to size of menu bar 1
+      return item 2 of menuSize as text
+    end if
+  end tell
+end tell
+return ""
+APPLESCRIPT
+)"
+
+  if [[ "$height" =~ ^[0-9]+$ ]] && [ "$height" -gt 0 ]; then
+    echo "$height"
+    return 0
+  fi
+
+  return 1
+}
+
+if [ -z "${DESKTOP_TOP_OFFSET:-}" ]; then
+  if DESKTOP_TOP_OFFSET="$(detect_menu_bar_height)"; then
+    log_info "Detected menu bar height: ${DESKTOP_TOP_OFFSET}px"
+  else
+    DESKTOP_TOP_OFFSET=28
+  fi
+fi
+
+if [[ ! "$DESKTOP_START_SPACE" =~ ^[0-9]+$ ]] || [ "$DESKTOP_START_SPACE" -lt 1 ]; then
+  die "DESKTOP_START_SPACE must be a positive integer (got: $DESKTOP_START_SPACE)."
+fi
+if [[ ! "$DESKTOP_TOP_OFFSET" =~ ^[0-9]+$ ]]; then
+  die "DESKTOP_TOP_OFFSET must be a non-negative integer (got: $DESKTOP_TOP_OFFSET)."
+fi
+if [[ ! "$DESKTOP_WINDOW_TIMEOUT" =~ ^[0-9]+$ ]] || [ "$DESKTOP_WINDOW_TIMEOUT" -lt 1 ]; then
+  die "DESKTOP_WINDOW_TIMEOUT must be a positive integer (got: $DESKTOP_WINDOW_TIMEOUT)."
+fi
+if [ "$DESKTOP_LAYOUT" != "left-right" ]; then
+  die "Unsupported DESKTOP_LAYOUT '$DESKTOP_LAYOUT'. Supported: left-right"
+fi
+
+space_key_code() {
+  case "$1" in
+    1) echo 18 ;;
+    2) echo 19 ;;
+    3) echo 20 ;;
+    4) echo 21 ;;
+    5) echo 23 ;;
+    6) echo 22 ;;
+    7) echo 26 ;;
+    8) echo 28 ;;
+    9) echo 25 ;;
+    *) return 1 ;;
+  esac
+}
+
+switch_to_space() {
+  local space="$1"
+  local key_code
+  key_code="$(space_key_code "$space")" || return 1
+
+  osascript \
+    -e 'tell application "System Events"' \
+    -e "key code $key_code using control down" \
+    -e 'end tell' >/dev/null 2>&1
+}
+
+get_screen_bounds() {
+  local bounds
+  bounds="$(osascript -e 'tell application "Finder" to get bounds of window of desktop' 2>/dev/null | tr -d ' ')"
+
+  if [[ "$bounds" =~ ^-?[0-9]+,-?[0-9]+,-?[0-9]+,-?[0-9]+$ ]]; then
+    IFS=',' read -r SCREEN_LEFT SCREEN_TOP SCREEN_RIGHT SCREEN_BOTTOM <<< "$bounds"
+  else
+    log_warn "Could not read screen bounds from Finder. Falling back to 1728x1117."
+    SCREEN_LEFT=0
+    SCREEN_TOP=0
+    SCREEN_RIGHT=1728
+    SCREEN_BOTTOM=1117
+  fi
+
+  if [ "$SCREEN_RIGHT" -le "$SCREEN_LEFT" ] || [ "$SCREEN_BOTTOM" -le "$SCREEN_TOP" ]; then
+    die "Invalid screen bounds detected: $SCREEN_LEFT,$SCREEN_TOP,$SCREEN_RIGHT,$SCREEN_BOTTOM"
+  fi
+
+  WORK_LEFT="$SCREEN_LEFT"
+  WORK_TOP=$((SCREEN_TOP + DESKTOP_TOP_OFFSET))
+  WORK_RIGHT="$SCREEN_RIGHT"
+  WORK_BOTTOM="$SCREEN_BOTTOM"
+
+  if [ "$WORK_TOP" -ge "$WORK_BOTTOM" ]; then
+    WORK_TOP="$SCREEN_TOP"
+  fi
+
+  WORK_WIDTH=$((WORK_RIGHT - WORK_LEFT))
+  MID_X=$((WORK_LEFT + (WORK_WIDTH / 2)))
+}
+
+cursor_window_exists() {
+  local slot_name="$1"
+  local exists
+
+  exists="$(osascript << APPLESCRIPT 2>/dev/null || true
+tell application "$DESKTOP_EDITOR"
+  if not running then return "0"
+  repeat with w in windows
+    try
+      if (name of w) contains "$slot_name" then return "1"
+    end try
+  end repeat
+  return "0"
+end tell
+APPLESCRIPT
+)"
+
+  [ "$exists" = "1" ]
+}
+
+browser_window_exists() {
+  local host_port="$1"
+  local exists
+
+  exists="$(osascript << APPLESCRIPT 2>/dev/null || true
+tell application "$DESKTOP_BROWSER"
+  if not running then return "0"
+  repeat with w in windows
+    try
+      set tabURL to URL of active tab of w
+      if tabURL contains "$host_port" then return "1"
+    end try
+  end repeat
+  return "0"
+end tell
+APPLESCRIPT
+)"
+
+  [ "$exists" = "1" ]
+}
+
+wait_for_cursor_window() {
+  local slot_name="$1"
+  local deadline=$((SECONDS + DESKTOP_WINDOW_TIMEOUT))
+
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    if cursor_window_exists "$slot_name"; then
+      return 0
+    fi
+    sleep 0.4
+  done
+
+  return 1
+}
+
+wait_for_browser_window() {
+  local host_port="$1"
+  local deadline=$((SECONDS + DESKTOP_WINDOW_TIMEOUT))
+
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    if browser_window_exists "$host_port"; then
+      return 0
+    fi
+    sleep 0.4
+  done
+
+  return 1
+}
+
+set_browser_bounds() {
+  local host_port="$1"
+  local applied
+
+  applied="$(osascript << APPLESCRIPT 2>/dev/null || true
+tell application "$DESKTOP_BROWSER"
+  if not running then return "0"
+  set movedCount to 0
+  repeat with w in windows
+    try
+      set tabURL to URL of active tab of w
+      if tabURL contains "$host_port" then
+        set bounds of w to {$WORK_LEFT, $WORK_TOP, $MID_X, $WORK_BOTTOM}
+        set movedCount to movedCount + 1
+      end if
+    end try
+  end repeat
+  return movedCount as text
+end tell
+APPLESCRIPT
+)"
+
+  [[ "$applied" =~ ^[0-9]+$ ]] && [ "$applied" -gt 0 ]
+}
+
+set_editor_bounds() {
+  local slot_name="$1"
+  local applied
+
+  applied="$(osascript << APPLESCRIPT 2>/dev/null || true
+tell application "$DESKTOP_EDITOR"
+  if not running then return "0"
+  set movedCount to 0
+  repeat with w in windows
+    try
+      if (name of w) contains "$slot_name" then
+        set bounds of w to {$MID_X, $WORK_TOP, $WORK_RIGHT, $WORK_BOTTOM}
+        set movedCount to movedCount + 1
+      end if
+    end try
+  end repeat
+  return movedCount as text
+end tell
+APPLESCRIPT
+)"
+
+  [[ "$applied" =~ ^[0-9]+$ ]] && [ "$applied" -gt 0 ]
+}
+
+slot_web_url() {
+  local slot_name="$1"
+  local port_base="$2"
+  local slot_num web_port slot_domain parsed
+
+  slot_num=$(( (port_base - PORT_BASE_START) / PORT_RANGE ))
+  web_port=$((port_base + 1))
+
+  if [ -n "${TS_SPLIT_DOMAIN:-}" ]; then
+    slot_domain="${SLOT_PROJECT_NAME}.${TS_SPLIT_DOMAIN}"
+  else
+    slot_domain="${SLOT_PROJECT_NAME}.flowslot.cc"
+  fi
+
+  if [ -f "$SLOT_SOURCE_DIR/flowslot-ports.sh" ]; then
+    if parsed="$(
+      SLOT="$slot_num" \
+      SLOT_NAME="$slot_name" \
+      SLOT_PORT_BASE="$port_base" \
+      SLOT_PROJECT_NAME="$SLOT_PROJECT_NAME" \
+      SLOT_REMOTE_IP="localhost" \
+      COMPOSE_PROJECT_NAME="${SLOT_PROJECT_NAME}-${slot_name}" \
+      TS_SPLIT_DOMAIN="${TS_SPLIT_DOMAIN:-}" \
+      bash -c '
+        set -euo pipefail
+        # shellcheck source=/dev/null
+        source "$1"
+        if [ -n "${SLOT_PORT_WEB:-}" ]; then
+          web_port="$SLOT_PORT_WEB"
+        else
+          web_port=$((SLOT_PORT_BASE + 1))
+        fi
+
+        if [ -n "${SLOT_DOMAIN:-}" ]; then
+          slot_domain="$SLOT_DOMAIN"
+        elif [ -n "${TS_SPLIT_DOMAIN:-}" ]; then
+          slot_domain="${SLOT_PROJECT_NAME}.${TS_SPLIT_DOMAIN}"
+        else
+          slot_domain="${SLOT_PROJECT_NAME}.flowslot.cc"
+        fi
+
+        echo "${web_port}|${slot_domain}"
+      ' _ "$SLOT_SOURCE_DIR/flowslot-ports.sh" 2>/dev/null
+    )"; then
+      web_port="${parsed%%|*}"
+      slot_domain="${parsed#*|}"
+    else
+      log_warn "Could not parse flowslot-ports.sh for slot '$slot_name'. Using defaults."
+    fi
+  fi
+
+  echo "http://web.${slot_domain}:${web_port}"
+}
+
+running_slots() {
+  ssh "$SLOT_REMOTE_HOST" bash << REMOTE_SCRIPT
+set -euo pipefail
+
+BASE_DIR="$SLOT_REMOTE_BASE"
+PROJECT="$SLOT_PROJECT_NAME"
+
+for slot_path in "\$BASE_DIR"/*/; do
+  [ -d "\$slot_path" ] || continue
+
+  dir_name=\$(basename "\$slot_path")
+
+  if [ ! -f "\$slot_path/docker-compose.yml" ] && [ ! -f "\$slot_path/docker-compose.dev.yml" ]; then
+    continue
+  fi
+
+  if [[ "\$dir_name" =~ -([0-9]{4})$ ]]; then
+    slot_name="\${dir_name%-[0-9][0-9][0-9][0-9]}"
+    port_base="\${BASH_REMATCH[1]}"
+  else
+    continue
+  fi
+
+  running=\$(docker ps --filter "name=\${PROJECT}-\${slot_name}" -q 2>/dev/null | wc -l | tr -d '[:space:]')
+  if [ "\${running:-0}" -gt 0 ] 2>/dev/null; then
+    echo "\${slot_name}|\${port_base}"
+  fi
+done
+REMOTE_SCRIPT
+}
+
+get_screen_bounds
+
+SLOT_DATA="$(running_slots)"
+if [ -z "$SLOT_DATA" ]; then
+  log_info "No running slots found. Nothing to launch."
+  exit 0
+fi
+
+mapfile -t SLOT_LINES < <(printf "%s\n" "$SLOT_DATA" | sed '/^$/d' | sort -t'|' -k2,2n)
+if [ "${#SLOT_LINES[@]}" -eq 0 ]; then
+  log_info "No running slots found. Nothing to launch."
+  exit 0
+fi
+
+LAST_SPACE=$((DESKTOP_START_SPACE + ${#SLOT_LINES[@]} - 1))
+if [ "$LAST_SPACE" -gt 9 ]; then
+  die "Need Space shortcuts up to Desktop $LAST_SPACE. Only Ctrl+1..Ctrl+9 are supported."
+fi
+
+log_warn "Ensure Desktops $DESKTOP_START_SPACE-$LAST_SPACE exist in Mission Control before continuing."
+
+TMP_STATE="$(mktemp)"
+trap 'rm -f "$TMP_STATE"' EXIT
+
+if [ -f "$DESKTOP_STATE_FILE" ]; then
+  cp "$DESKTOP_STATE_FILE" "$TMP_STATE"
+else
+  echo "# Managed by slot desktop up" > "$TMP_STATE"
+  echo "# slot|space|dir|url" >> "$TMP_STATE"
+fi
+
+declare -a SUMMARY_LINES=()
+launched_count=0
+skipped_count=0
+space="$DESKTOP_START_SPACE"
+
+for row in "${SLOT_LINES[@]}"; do
+  IFS='|' read -r slot_name port_base <<< "$row"
+  [ -z "$slot_name" ] && continue
+  [ -z "$port_base" ] && continue
+
+  validate_slot_name "$slot_name"
+
+  slot_dir="$SLOT_SLOTS_DIR/$slot_name"
+  if [ ! -d "$slot_dir" ]; then
+    log_warn "Slot '$slot_name' not found locally at $slot_dir. Skipping."
+    skipped_count=$((skipped_count + 1))
+    space=$((space + 1))
+    continue
+  fi
+
+  slot_url="$(slot_web_url "$slot_name" "$port_base")"
+  host_port="${slot_url#http://}"
+  host_port="${host_port%%/*}"
+
+  if cursor_window_exists "$slot_name"; then
+    log_warn "Cursor window for slot '$slot_name' already open. Skipping (use 'slot desktop restart')."
+    skipped_count=$((skipped_count + 1))
+    space=$((space + 1))
+    continue
+  fi
+
+  if browser_window_exists "$host_port"; then
+    log_warn "$DESKTOP_BROWSER window for '$host_port' already open. Skipping (use 'slot desktop restart')."
+    skipped_count=$((skipped_count + 1))
+    space=$((space + 1))
+    continue
+  fi
+
+  log_info "Space $space -> slot '$slot_name'"
+
+  if ! switch_to_space "$space"; then
+    die "Failed to switch to Desktop $space. Enable Mission Control shortcuts Ctrl+1..Ctrl+9."
+  fi
+
+  sleep "$DESKTOP_SWITCH_DELAY"
+
+  open -a "$DESKTOP_EDITOR" "$slot_dir" >/dev/null 2>&1 || {
+    log_warn "Failed to launch $DESKTOP_EDITOR for slot '$slot_name'."
+    skipped_count=$((skipped_count + 1))
+    space=$((space + 1))
+    continue
+  }
+
+  if [ "$DESKTOP_BROWSER" = "Google Chrome" ]; then
+    open -n -a "$DESKTOP_BROWSER" --args --new-window "$slot_url" >/dev/null 2>&1 || {
+      log_warn "Failed to launch $DESKTOP_BROWSER for slot '$slot_name'."
+      skipped_count=$((skipped_count + 1))
+      space=$((space + 1))
+      continue
+    }
+  else
+    open -a "$DESKTOP_BROWSER" "$slot_url" >/dev/null 2>&1 || {
+      log_warn "Failed to launch $DESKTOP_BROWSER for slot '$slot_name'."
+      skipped_count=$((skipped_count + 1))
+      space=$((space + 1))
+      continue
+    }
+  fi
+
+  if ! wait_for_cursor_window "$slot_name"; then
+    log_warn "Timed out waiting for $DESKTOP_EDITOR window for slot '$slot_name'."
+  fi
+  if ! wait_for_browser_window "$host_port"; then
+    log_warn "Timed out waiting for $DESKTOP_BROWSER window for $host_port."
+  fi
+
+  if ! set_browser_bounds "$host_port"; then
+    log_warn "Could not position browser window for slot '$slot_name'."
+  fi
+  if ! set_editor_bounds "$slot_name"; then
+    log_warn "Could not position editor window for slot '$slot_name'."
+  fi
+
+  grep -Ev "^${slot_name}\|" "$TMP_STATE" > "${TMP_STATE}.next" || true
+  mv "${TMP_STATE}.next" "$TMP_STATE"
+  echo "${slot_name}|${space}|${slot_dir}|${slot_url}" >> "$TMP_STATE"
+
+  SUMMARY_LINES+=("${slot_name}|${space}|${slot_url}")
+  launched_count=$((launched_count + 1))
+  space=$((space + 1))
+done
+
+if [ "$launched_count" -gt 0 ]; then
+  mv "$TMP_STATE" "$DESKTOP_STATE_FILE"
+  trap - EXIT
+  success "Desktop layout updated ($launched_count slot(s) launched)."
+else
+  log_warn "No new slot windows were launched."
+fi
+
+if [ "$skipped_count" -gt 0 ]; then
+  log_warn "$skipped_count slot(s) were skipped."
+fi
+
+if [ "${#SUMMARY_LINES[@]}" -gt 0 ]; then
+  echo ""
+  printf "%-15s %-8s %s\n" "SLOT" "SPACE" "URL"
+  echo "--------------------------------------------------------------"
+  for line in "${SUMMARY_LINES[@]}"; do
+    IFS='|' read -r slot_name slot_space slot_url <<< "$line"
+    printf "%-15s %-8s %s\n" "$slot_name" "$slot_space" "$slot_url"
+  done
+  echo ""
+  echo "State file: $DESKTOP_STATE_FILE"
+fi

--- a/scripts/slot-destroy
+++ b/scripts/slot-destroy
@@ -78,6 +78,10 @@ fi
 
 log_info "Destroying slot '$SLOT_NAME'..."
 
+# Kill any lingering Claude tmux session for this slot so the SSH session
+# closes cleanly and the destroy isn't blocked by an attached terminal.
+ssh "$SLOT_REMOTE_HOST" "tmux kill-session -t 'claude-${SLOT_NAME}' 2>/dev/null" || true
+
 # Stop containers
 log_info "Stopping containers..."
 ssh "$SLOT_REMOTE_HOST" bash << REMOTE_SCRIPT

--- a/scripts/slot-self-init
+++ b/scripts/slot-self-init
@@ -136,6 +136,28 @@ if [ ! -f "$SOURCE_DIR/flowslot-ports.sh" ]; then
   echo "See: $SCRIPT_DIR/../templates/flowslot-ports.example.sh"
 fi
 
+# Optional: Claude Code / CallMeBot notification setup
+echo ""
+echo "Enable 'slot claude' (run Claude Code on slots, phone-call on finish)?"
+read -r -p "Configure now? [y/N] " ENABLE_CLAUDE
+CALLMEBOT_PHONE=""
+CALLMEBOT_APIKEY=""
+CALLMEBOT_CHANNEL="whatsapp"
+SLOT_CLAUDE_DEFAULT_VAL="remote"
+if [[ "$ENABLE_CLAUDE" =~ ^[Yy]$ ]]; then
+  echo "  CallMeBot channel (whatsapp | signal | telegram | call):"
+  read -r -p "  [whatsapp]: " CHANNEL_INPUT
+  CALLMEBOT_CHANNEL="${CHANNEL_INPUT:-whatsapp}"
+  echo "  Phone number (international format, e.g. +46701234567; for 'telegram'/'call' use @username):"
+  read -r -p "  phone: " CALLMEBOT_PHONE
+  echo "  CallMeBot API key (get one at callmebot.com; skip with empty for 'telegram'):"
+  read -r -s -p "  apikey: " CALLMEBOT_APIKEY
+  echo ""
+  echo "  Default 'slot claude' target (remote | local):"
+  read -r -p "  [remote]: " DEFAULT_INPUT
+  SLOT_CLAUDE_DEFAULT_VAL="${DEFAULT_INPUT:-remote}"
+fi
+
 # Create .slotconfig
 cat > ".slotconfig" << EOF
 # Created by: slot init
@@ -150,6 +172,13 @@ SLOT_REMOTE_BASE="$REMOTE_BASE"
 SLOT_AWS_INSTANCE_ID="$AWS_INSTANCE_ID"
 SLOT_AWS_REGION="$AWS_REGION"
 SLOT_COMPOSE_FILES="$COMPOSE_FILES"
+
+# Claude Code integration ('slot claude'). Leave phone/apikey empty to disable
+# the phone-call notification hook.
+FLOWSLOT_CALLMEBOT_PHONE="$CALLMEBOT_PHONE"
+FLOWSLOT_CALLMEBOT_APIKEY="$CALLMEBOT_APIKEY"
+FLOWSLOT_CALLMEBOT_CHANNEL="$CALLMEBOT_CHANNEL"
+SLOT_CLAUDE_DEFAULT="$SLOT_CLAUDE_DEFAULT_VAL"
 EOF
 
 echo ""

--- a/templates/claude-settings.example.json
+++ b/templates/claude-settings.example.json
@@ -1,0 +1,27 @@
+{
+  "_comment": "Hook block that flowslot merges into ~/.claude/settings.json on each slot. The absolute path to flowslot-notify is substituted at deploy time by scripts/lib/claude.sh:deploy_notify_hook. Kept here for reference / manual deployment.",
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.flowslot/bin/flowslot-notify stop"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.flowslot/bin/flowslot-notify notification"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add `slot desktop up|down|restart` command group in the main CLI
- implement macOS desktop automation scripts for sequential Space switching, app launch, window tiling, and state tracking
- add optional desktop config support via `.slotdesktop` / `.slotconfig` defaults and document one-time Mission Control + Accessibility setup
- update README command table and add changelog entry

## macOS step-by-step setup and test guide
1. Open **System Settings → Desktop & Dock → Mission Control** and set **Automatically rearrange Spaces based on most recent use** to **OFF**.
2. Open **System Settings → Keyboard → Keyboard Shortcuts → Mission Control** and enable **Switch to Desktop 1 ... Desktop N** (`Ctrl+1 ... Ctrl+N`).
3. Open Mission Control (`Ctrl+Up`) and create enough Spaces with the `+` button (one per running slot, starting from your configured `DESKTOP_START_SPACE`).
4. Grant Accessibility permissions to your terminal app (**System Settings → Privacy & Security → Accessibility**), and ensure Chrome/Cursor can be controlled.
5. In a project initialized with flowslot, start your infra and slots, for example:
   - `slot server start`
   - `slot create auth`
   - `slot create feature`
6. Run `slot desktop up` from the project (or a slot directory with `.slotconfig` available).
7. Validate layout:
   - each running slot is assigned to a sequential Space
   - browser window is on the left half
   - Cursor window for that slot is on the right half
8. Run `slot desktop down` and verify only managed windows close (personal Chrome windows/tabs should remain).
9. Run `slot desktop restart` to verify recovery flow (`down` + `up`) after browser/editor restart/update.
10. Optional: create `.slotdesktop` to customize behavior (example):
    ```bash
    DESKTOP_START_SPACE=3
    DESKTOP_LAYOUT="left-right"
    DESKTOP_BROWSER="Google Chrome"
    DESKTOP_EDITOR="Cursor"
    DESKTOP_TOP_OFFSET=28
    DESKTOP_WINDOW_TIMEOUT=10
    ```

## Testing
- `bash -n scripts/slot scripts/slot-desktop-up.sh scripts/slot-desktop-down.sh scripts/slot-desktop-restart.sh`
- `scripts/slot --help`
- `scripts/slot-desktop-up.sh --help`
- `scripts/slot-desktop-down.sh --help`
- `scripts/slot-desktop-restart.sh --help`

## Notes
- GUI behavior requires local macOS Accessibility permissions and Mission Control desktop shortcuts.
- Space switching is limited to shortcuts Desktop 1-9.
