### PR TITLE
feat(slot): enable git commit+push from slots via fine-grained GitHub PAT

### DIFF
--- a/config.example
+++ b/config.example
@@ -34,6 +34,20 @@ export TS_SPLIT_DOMAIN="flowslot.cc"
 export AWS_KEY_NAME="flowslot-dev"
 
 # =============================================================================
+# OPTIONAL: `slot create` sets up a real git origin on each slot so Claude Code
+# (running on the slot) can commit and push. Requires a GitHub token.
+#
+# FLOWSLOT_GITHUB_TOKEN    Fine-grained GitHub Personal Access Token with
+#                          `Contents: Read and write` on the target repo only.
+#                          Create at https://github.com/settings/personal-access-tokens/new
+#                          Store per-project in .slotconfig (slot self init prompts for it).
+#                          The EC2 stores the token in ~/.git-credentials (0600)
+#                          via the `store` credential helper; any slot inherits it.
+# FLOWSLOT_GIT_USER_NAME   Commit author name on slots (default: flowslot-bot).
+# FLOWSLOT_GIT_USER_EMAIL  Commit author email (default: flowslot-bot@flowslot.cc).
+# =============================================================================
+
+# =============================================================================
 # OPTIONAL: `slot claude voice` — bidirectional phone conversations with Claude
 # Code on a slot, via ElevenLabs Conversational AI.
 #

--- a/infra/bridge/server.py
+++ b/infra/bridge/server.py
@@ -57,15 +57,6 @@ def verify_hmac(path: str, body: bytes, signature: str | None) -> bool:
     return hmac.compare_digest(expected, provided)
 
 
-def verify_static_token(token: str | None) -> bool:
-    """Verify a static bearer token (X-Flowslot-Token header) against the shared
-    secret. ElevenLabs CAI's tool config supports static request headers cleanly
-    but doesn't offer per-request HMAC signing."""
-    if not token:
-        return False
-    return hmac.compare_digest(SECRET.decode(), token.strip().removeprefix("Bearer ").strip())
-
-
 # --- SQLite helpers ---
 
 def db_connect() -> sqlite3.Connection:
@@ -249,14 +240,8 @@ class Handler(BaseHTTPRequestHandler):
         return self.rfile.read(length) if length > 0 else b""
 
     def _signature_ok(self, body: bytes) -> bool:
-        # Accept either HMAC signature OR a static bearer token — ElevenLabs
-        # CAI's dashboard supports static headers cleanly but not HMAC signing.
         sig = self.headers.get("X-Flowslot-Signature") or self.headers.get("x-flowslot-signature")
-        if sig and verify_hmac(self.path, body, sig):
-            return True
-        token = (self.headers.get("X-Flowslot-Token") or self.headers.get("x-flowslot-token")
-                 or self.headers.get("Authorization"))
-        return verify_static_token(token)
+        return verify_hmac(self.path, body, sig)
 
     def _reply(self, status: int, payload: dict | str):
         if isinstance(payload, str):
@@ -271,7 +256,6 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Cache-Control", "no-store")
         self.end_headers()
         self.wfile.write(data)
-        log(f"[bridge] {self.command} {self.path} -> {status} ({len(data)}B)")
 
     def _unauthorized(self):
         self._reply(401, {"error": "invalid signature"})

--- a/infra/bridge/server.py
+++ b/infra/bridge/server.py
@@ -57,6 +57,15 @@ def verify_hmac(path: str, body: bytes, signature: str | None) -> bool:
     return hmac.compare_digest(expected, provided)
 
 
+def verify_static_token(token: str | None) -> bool:
+    """Verify a static bearer token (X-Flowslot-Token header) against the shared
+    secret. ElevenLabs CAI's tool config supports static request headers cleanly
+    but doesn't offer per-request HMAC signing."""
+    if not token:
+        return False
+    return hmac.compare_digest(SECRET.decode(), token.strip().removeprefix("Bearer ").strip())
+
+
 # --- SQLite helpers ---
 
 def db_connect() -> sqlite3.Connection:
@@ -240,8 +249,14 @@ class Handler(BaseHTTPRequestHandler):
         return self.rfile.read(length) if length > 0 else b""
 
     def _signature_ok(self, body: bytes) -> bool:
+        # Accept either HMAC signature OR a static bearer token — ElevenLabs
+        # CAI's dashboard supports static headers cleanly but not HMAC signing.
         sig = self.headers.get("X-Flowslot-Signature") or self.headers.get("x-flowslot-signature")
-        return verify_hmac(self.path, body, sig)
+        if sig and verify_hmac(self.path, body, sig):
+            return True
+        token = (self.headers.get("X-Flowslot-Token") or self.headers.get("x-flowslot-token")
+                 or self.headers.get("Authorization"))
+        return verify_static_token(token)
 
     def _reply(self, status: int, payload: dict | str):
         if isinstance(payload, str):
@@ -256,6 +271,7 @@ class Handler(BaseHTTPRequestHandler):
         self.send_header("Cache-Control", "no-store")
         self.end_headers()
         self.wfile.write(data)
+        log(f"[bridge] {self.command} {self.path} -> {status} ({len(data)}B)")
 
     def _unauthorized(self):
         self._reply(401, {"error": "invalid signature"})

--- a/scripts/lib/slot-git.sh
+++ b/scripts/lib/slot-git.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Helpers for enabling git push-from-slot. Sourced by scripts/slot-create and
+# other places that need git on the slot's remote dir.
+#
+# Design:
+#   - Mutagen is configured to ignore `.git`, so the slot's remote dir has
+#     files but no git metadata by default. Claude on the slot can edit but
+#     can't commit/push.
+#   - These helpers create a real .git on the slot linked to origin, so Claude
+#     has full upstream history. The slot's git is INDEPENDENT of the Mac's:
+#       - Mac-side: user's editor/`slot claude attach` workflow, commits from Mac
+#       - Slot-side: Claude Code's commits, pushed via FLOWSLOT_GITHUB_TOKEN
+#     Both target the same GitHub repo over HTTPS; branch collisions = user's
+#     problem (same as two laptops of the same dev).
+#   - Credential helper is global on the EC2 user (once per machine), so every
+#     slot inherits auth without re-injecting the token per-slot.
+
+# Ensure the ubuntu user on the EC2 has a global git credential helper that
+# reads from ~/.git-credentials, populated with the FLOWSLOT_GITHUB_TOKEN.
+# Idempotent; safe to run on every slot create.
+ensure_slot_git_credentials() {
+  local host="$1"
+  local token="$2"
+  [ -n "$token" ] || { log_warn "FLOWSLOT_GITHUB_TOKEN not set; skipping git credential setup"; return 1; }
+
+  # shellcheck disable=SC2029
+  ssh "$host" bash -s "$token" << 'REMOTE_CREDS'
+    set -e
+    token="$1"
+    umask 077
+    git config --global credential.helper store
+    # Preserve any existing non-github lines
+    existing=""
+    if [ -f "$HOME/.git-credentials" ]; then
+      existing="$(grep -v 'github.com' "$HOME/.git-credentials" 2>/dev/null || true)"
+    fi
+    { [ -n "$existing" ] && echo "$existing"; printf 'https://oauth2:%s@github.com\n' "$token"; } > "$HOME/.git-credentials"
+    chmod 600 "$HOME/.git-credentials"
+REMOTE_CREDS
+}
+
+# Initialize a real git repo on the slot linked to origin.
+#
+# $1 = ssh host, $2 = absolute remote slot path, $3 = repo URL,
+# $4 = branch name, $5 = git user.name, $6 = git user.email
+#
+# The sequence:
+#   1. git init
+#   2. git remote add origin
+#   3. git fetch --depth=1 origin $BRANCH  (shallow, fast)
+#   4. git reset --mixed FETCH_HEAD        (HEAD+index = upstream tree,
+#                                           working tree = mutagen-synced files)
+#   5. git branch -M $BRANCH               (rename default branch to target)
+# Result: working tree is what mutagen synced; `git status` shows real diffs
+# from upstream; Claude can commit on top and push cleanly.
+init_slot_git() {
+  local host="$1"
+  local remote_path="$2"
+  local repo_url="$3"
+  local branch="$4"
+  local user_name="$5"
+  local user_email="$6"
+
+  # shellcheck disable=SC2029
+  ssh "$host" bash -s "$remote_path" "$repo_url" "$branch" "$user_name" "$user_email" << 'REMOTE_GIT_INIT'
+    set -e
+    remote_path="$1"
+    repo_url="$2"
+    branch="$3"
+    user_name="$4"
+    user_email="$5"
+
+    cd "$remote_path"
+    if [ -d .git ]; then
+      # Idempotent: if already initialized, just make sure origin points at repo_url
+      git remote remove origin 2>/dev/null || true
+      git remote add origin "$repo_url"
+    else
+      git init --quiet
+      git remote add origin "$repo_url"
+      # Fetch the target branch shallowly, then align HEAD/index with upstream
+      # without overwriting the mutagen-synced working tree.
+      if git fetch --quiet --depth=1 origin "$branch" 2>/dev/null; then
+        git reset --mixed --quiet FETCH_HEAD
+        # Rename current branch to the target (no-op if already named that)
+        git branch -M "$branch" 2>/dev/null || true
+        git branch --set-upstream-to="origin/$branch" "$branch" 2>/dev/null || true
+      else
+        # Branch doesn't exist upstream yet (new-branch slot) — just align with main
+        # so Claude's commits have real history, push creates the new branch.
+        base=""
+        if git fetch --quiet --depth=1 origin main 2>/dev/null; then base=main
+        elif git fetch --quiet --depth=1 origin master 2>/dev/null; then base=master
+        fi
+        if [ -n "$base" ]; then
+          git reset --mixed --quiet FETCH_HEAD
+          git checkout -B "$branch" --quiet
+        else
+          # No upstream base reachable; commit everything as an initial snapshot
+          git add -A
+          git -c user.name="$user_name" -c user.email="$user_email" commit --quiet \
+            -m "initial slot snapshot" || true
+        fi
+      fi
+    fi
+
+    # Set slot-local identity so Claude's commits are attributed consistently
+    git config user.name  "$user_name"
+    git config user.email "$user_email"
+REMOTE_GIT_INIT
+}
+
+# Wrapper: set up credentials + init git + report origin. Safe default values
+# for name/email so Claude's commits don't error out.
+setup_slot_git() {
+  local host="$1"
+  local remote_path="$2"
+  local repo_url="$3"
+  local branch="$4"
+
+  local token="${FLOWSLOT_GITHUB_TOKEN:-}"
+  local name="${FLOWSLOT_GIT_USER_NAME:-flowslot-bot}"
+  local email="${FLOWSLOT_GIT_USER_EMAIL:-flowslot-bot@flowslot.cc}"
+
+  if [ -z "$token" ]; then
+    log_warn "FLOWSLOT_GITHUB_TOKEN not set in .slotconfig; slot's git will lack push credentials."
+    log_warn "Add the token to enable push from the slot."
+    # Still init git so Claude has upstream history; push will prompt for auth.
+  else
+    ensure_slot_git_credentials "$host" "$token"
+  fi
+
+  log_info "Initializing git on slot with origin=$repo_url branch=$branch..."
+  init_slot_git "$host" "$remote_path" "$repo_url" "$branch" "$name" "$email"
+}

--- a/scripts/slot-create
+++ b/scripts/slot-create
@@ -10,6 +10,8 @@ LIB_DIR="$SCRIPT_DIR/lib"
 # Source common functions
 # shellcheck source=lib/common.sh
 source "$LIB_DIR/common.sh"
+# shellcheck source=lib/slot-git.sh
+source "$LIB_DIR/slot-git.sh"
 
 show_help() {
   cat << EOF
@@ -190,6 +192,11 @@ for i in {1..30}; do
   fi
   sleep 1
 done
+
+# Initialize real git on the slot so Claude Code (running there) can commit
+# and push. Mutagen ignores .git, so without this the slot has files but no
+# git metadata. Uses FLOWSLOT_GITHUB_TOKEN from .slotconfig (optional).
+setup_slot_git "$SLOT_REMOTE_HOST" "$REMOTE_PATH" "$REPO_URL" "$BRANCH"
 
 # Get Tailscale IP for accessing services
 TAILSCALE_IP=$(ssh "$SLOT_REMOTE_HOST" "tailscale ip -4 2>/dev/null" | head -1 || echo "")

--- a/scripts/slot-self-init
+++ b/scripts/slot-self-init
@@ -136,6 +136,20 @@ if [ ! -f "$SOURCE_DIR/flowslot-ports.sh" ]; then
   echo "See: $SCRIPT_DIR/../templates/flowslot-ports.example.sh"
 fi
 
+# Optional: GitHub token so slots can `git push` (Claude commits from the slot)
+echo ""
+echo "Allow slots to git push? (Claude Code committing from a slot needs a token.)"
+echo "Create one at https://github.com/settings/personal-access-tokens/new"
+echo "  - Scope to THIS repo only"
+echo "  - Permissions: Contents = Read and write"
+echo "  - Set 90-day expiry; rotate when it expires"
+read -r -p "Configure now? [y/N] " ENABLE_PUSH
+GH_TOKEN=""
+if [[ "$ENABLE_PUSH" =~ ^[Yy]$ ]]; then
+  read -r -s -p "  GitHub PAT (starts with github_pat_): " GH_TOKEN
+  echo ""
+fi
+
 # Optional: Claude Code voice chat via ElevenLabs CAI
 echo ""
 echo "Enable 'slot claude voice' (bidirectional phone chat with Claude via ElevenLabs CAI)?"
@@ -174,6 +188,11 @@ SLOT_REMOTE_BASE="$REMOTE_BASE"
 SLOT_AWS_INSTANCE_ID="$AWS_INSTANCE_ID"
 SLOT_AWS_REGION="$AWS_REGION"
 SLOT_COMPOSE_FILES="$COMPOSE_FILES"
+
+# Fine-grained GitHub PAT scoped to this repo (contents: read/write).
+# Used by slot-create so each slot has a real git origin and can push.
+# Leave empty to create slots without push credentials.
+FLOWSLOT_GITHUB_TOKEN="$GH_TOKEN"
 
 # 'slot claude voice' — bidirectional phone chat via ElevenLabs Conversational AI.
 # Leave any field empty to skip; 'slot claude voice enable' will prompt later.


### PR DESCRIPTION
## Summary

Fixes a design gap uncovered when testing \`slot claude voice\` end-to-end: mutagen's \`--ignore=.git\` config means slots have files but no git metadata, so Claude Code running on a slot can edit but cannot commit or push. Users had to do all git work from the Mac side, which breaks autonomous Claude-on-slot task completion.

New behavior: \`slot create\` initializes a real \`.git\` on the slot's remote dir linked to origin. The working tree remains the mutagen-synced files; HEAD + index are aligned with upstream, so \`git status\` shows actual diffs, commits stack on real history, and pushes produce PR-ready branches.

## How auth works

- One fine-grained GitHub PAT per project (Contents: Read/Write scoped to one repo, 90-day expiry recommended)
- Stored in \`.slotconfig\` as \`FLOWSLOT_GITHUB_TOKEN\` — per-project, not tracked in the user's repo (\`.slotconfig\` is already gitignored in most setups; flowslot itself never sees it)
- On each \`slot create\`, the token is written to \`~/.git-credentials\` (0600) on the EC2 via git's \`store\` credential helper (configured \`--global\` once per EC2 user)
- Any slot on that EC2 inherits auth automatically; no per-slot re-injection needed

## Files

**New:**
- \`scripts/lib/slot-git.sh\` — helpers (\`ensure_slot_git_credentials\`, \`init_slot_git\`, \`setup_slot_git\`)

**Modified:**
- \`scripts/slot-create\` — sources the lib, calls \`setup_slot_git\` after mutagen sync completes
- \`scripts/slot-self-init\` — prompts for the PAT with clear scope instructions (\"Contents: Read/Write on THIS repo only\")
- \`config.example\` — documents \`FLOWSLOT_GITHUB_TOKEN\`, \`FLOWSLOT_GIT_USER_NAME\`, \`FLOWSLOT_GIT_USER_EMAIL\`

## Test plan

- [x] Manually configured existing slot (\`model-refresh-7700\` on thunder): added origin + credential helper, \`git push\` to a real GitHub branch succeeded
- [x] Sweep-verified no token exposure in the diff (fine-grained PAT lives only in per-project \`.slotconfig\`)
- [ ] Next \`slot create\` on any project with \`FLOWSLOT_GITHUB_TOKEN\` set should produce a slot where \`git remote -v\` points at origin and \`git push\` works without further setup

## Security notes

- PAT is a bearer credential. If the slot's filesystem is compromised (e.g., prompt-injected Claude exfiltrating env vars), the token leaks. Mitigated by: fine-grained scope to one repo, 90-day expiry, trivial GitHub revocation.
- For tighter security, a future PR can replace this with GitHub App installation tokens (auto-expire in 1h, revoke by uninstalling the app). Out of scope for this change; the simpler PAT path unblocks the common case today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)