### PR TITLE
fix(agent-push): clear prompt.tool_ids when sending inline tools

### DIFF
--- a/scripts/lib/claude-voice.sh
+++ b/scripts/lib/claude-voice.sh
@@ -548,13 +548,19 @@ agent_block = current["conversation_config"]["agent"]
 prompt_block = agent_block.get("prompt") or {}
 
 # 3. Build PATCH body: replace prompt.tools + prompt.prompt only.
+# ElevenLabs rejects both `tools` (inline) and `tool_ids` (workspace refs)
+# in the same prompt block, so we explicitly null tool_ids when sending
+# inline tools. Strip our copied tool_ids before the merge.
+prompt_block = {k: v for k, v in prompt_block.items()
+                if k not in ("tools", "tool_ids")}
 patch = {
     "conversation_config": {
         "agent": {
             "prompt": {
                 **prompt_block,
-                "prompt": prompt_text,
-                "tools":  tools_eleven,
+                "prompt":   prompt_text,
+                "tools":    tools_eleven,
+                "tool_ids": [],
             }
         }
     }


### PR DESCRIPTION
## Summary

`slot claude voice agent-push` (introduced in v2.15.0) failed on its first
real-world run against the thunder agent with:

```
HTTP 400 on PATCH: "Cannot specify both tools and tool IDs - please
provide only one of these options."
```

The thunder agent was set up via dashboard in v2.13, so its current
`conversation_config.agent.prompt` already carries `tool_ids: [...]`
(workspace-scoped references). Our PATCH copied the existing prompt
block and added `tools: [...]` (inline) on top, leaving both populated.

Fix: drop `tools` *and* `tool_ids` from the copied prompt block before the
merge, then write `tools: <new>` and `tool_ids: []`. Verified live —
PATCH succeeds and all 6 tools land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)